### PR TITLE
Fix how plugin_path is used.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,6 @@ plugins {
 
 apply plugin: 'com.github.johnrengelman.shadow'
 
-//Put your plugins folder directory here! If it is left as '', jars will only be copied if the parent project has a path specified
-ext.plugin_path = ''
 
 group = 'com.derongan.minecraft'
 version = pluginVersion + "-SNAPSHOT"
@@ -58,18 +56,11 @@ shadowJar {
 build.dependsOn shadowJar
 
 //Move into plugins folder
-if (plugin_path != '') {
-    println("Copying to plugin directory")
+if (project.hasProperty("plugin_path") && plugin_path) {
+    println("Copying to plugin directory $plugin_path")
     task copyJar(type: Copy) {
         from shadowJar // here it automatically reads jar file produced from jar task
         into plugin_path
     }
     build.dependsOn copyJar
-} else if (parent != null && parent.hasProperty("plugin_path")) {
-    println("Copying to parent project's plugin directory")
-    task copyJar(type: Copy) {
-        from shadowJar
-        into parent.ext.plugin_path
-    }
-    build.dependsOn copyJar
-} else println("Skipped copyJar")
+}


### PR DESCRIPTION
Now source from project properties organically rather than using extended properties
Simplify using parents properties
Show directory being copied into