### PR TITLE
Change Movement Listener priority to LOW

### DIFF
--- a/src/main/java/com/derongan/minecraft/deeperworld/MovementListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/MovementListener.kt
@@ -15,7 +15,7 @@ import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerMoveEvent
 
 class MovementListener(private val playerManager: PlayerManager) : Listener {
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     fun onPlayerMove(playerMoveEvent: PlayerMoveEvent) {
         val player = playerMoveEvent.player
         if (player.hasPermission(Permissions.CHANGE_SECTION_PERMISSION) && playerManager.playerCanTeleport(player)) {

--- a/src/main/java/com/derongan/minecraft/deeperworld/MovementListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/MovementListener.kt
@@ -15,7 +15,7 @@ import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerMoveEvent
 
 class MovementListener(private val playerManager: PlayerManager) : Listener {
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     fun onPlayerMove(playerMoveEvent: PlayerMoveEvent) {
         val player = playerMoveEvent.player
         if (player.hasPermission(Permissions.CHANGE_SECTION_PERMISSION) && playerManager.playerCanTeleport(player)) {


### PR DESCRIPTION
https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/EventPriority.html

```
LOWEST - Event call is of very low importance and should be ran first, to allow other plugins to further customise the outcome
```

I know its confusing.