### PR TITLE
Sync more events

### DIFF
--- a/src/main/java/com/derongan/minecraft/deeperworld/synchronization/SectionSyncListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/synchronization/SectionSyncListener.kt
@@ -62,10 +62,11 @@ object SectionSyncListener : Listener {
         blockEvent.newState.updateBlock()
     }
 
-    @EventHandler
+    //TODO this causes duplication glitches that need to be fixed first
+    /*@EventHandler
     fun onBlockMultiPlaceEvent(blockEvent: BlockMultiPlaceEvent) {
         blockEvent.replacedBlockStates.copyBlocks()
-    }
+    }*/
 
     /** Disables pistons extending if they are in the overlap of two sections */
     @EventHandler

--- a/src/main/java/com/derongan/minecraft/deeperworld/synchronization/SectionSyncListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/synchronization/SectionSyncListener.kt
@@ -4,13 +4,11 @@ import com.derongan.minecraft.deeperworld.DeeperContext
 import com.derongan.minecraft.deeperworld.world.section.*
 import com.mineinabyss.idofront.messaging.color
 import com.mineinabyss.idofront.messaging.logInfo
-import com.mineinabyss.idofront.messaging.logVal
 import nl.rutgerkok.blocklocker.BlockLockerAPIv2
 import nl.rutgerkok.blocklocker.SearchMode
 import org.bukkit.Chunk
 import org.bukkit.Material
 import org.bukkit.block.Block
-import org.bukkit.block.BlockState
 import org.bukkit.block.Container
 import org.bukkit.block.Sign
 import org.bukkit.block.data.Waterlogged
@@ -19,7 +17,6 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.*
-import org.bukkit.event.entity.EntityBreakDoorEvent
 import org.bukkit.event.entity.EntityExplodeEvent
 import org.bukkit.event.inventory.InventoryCloseEvent
 import org.bukkit.event.inventory.InventoryPickupItemEvent
@@ -34,7 +31,7 @@ import org.bukkit.inventory.ItemStack
  */
 object SectionSyncListener : Listener {
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
-    fun onBlockBreakEvent(blockBreakEvent: BlockEvent) {
+    fun onBlockBreakEvent(blockBreakEvent: BlockBreakEvent) {
         val block = blockBreakEvent.block
         updateCorrespondingBlock(block.location) { original, corr ->
             val state = corr.state
@@ -44,7 +41,6 @@ object SectionSyncListener : Listener {
                 corrInv.clear()
             }
             if (DeeperContext.isBlockLockerLoaded && state is Sign && state.lines[0] == "[Private]") {
-                //TODO ignore blocklocker code if it isn't present
                 blockLocker.protectionFinder.findProtection(corr, SearchMode.ALL).ifPresent {
                     it.signs.forEach { linkedSign -> linkedSign.location.block.type = Material.AIR }
                 }
@@ -68,15 +64,7 @@ object SectionSyncListener : Listener {
 
     @EventHandler
     fun onBlockMultiPlaceEvent(blockEvent: BlockMultiPlaceEvent) {
-        blockEvent.replacedBlockStates.logVal("states ").copyBlocks()
-    }
-
-    //TODO make a clean way for some basic stuff like this to be used for all the listeners
-    private fun List<BlockState>.copyBlocks() = forEach { it.copyBlock() }
-    private fun BlockState.copyBlock() = updateCorrespondingBlock(location, copyBlockData)
-    private fun List<BlockState>.updateBlocks() = forEach { it.updateBlock() }
-    private fun BlockState.updateBlock() = updateCorrespondingBlock(location) { _, corresponding ->
-        corresponding.blockData = this.blockData
+        blockEvent.replacedBlockStates.copyBlocks()
     }
 
     /** Disables pistons extending if they are in the overlap of two sections */

--- a/src/main/java/com/derongan/minecraft/deeperworld/synchronization/Updaters.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/synchronization/Updaters.kt
@@ -13,7 +13,7 @@ import org.bukkit.util.Vector
 
 internal val blockLocker: BlockLockerPlugin by lazy { BlockLockerAPIv2.getPlugin() }
 
-internal val updateBlockData = { original: Block, corresponding: Block ->
+internal val copyBlockData = { original: Block, corresponding: Block ->
     corresponding.blockData = original.blockData.clone()
 }
 
@@ -27,7 +27,7 @@ internal fun updateCorrespondingBlock(original: Location, updater: (original: Bl
 }
 
 internal fun signUpdater(lines: Array<String>? = null) = { original: Block, corresponding: Block ->
-    updateBlockData(original, corresponding)
+    copyBlockData(original, corresponding)
     val sign = original.state
     if (sign is Sign) {
         val readLines = lines ?: sign.lines

--- a/src/main/java/com/derongan/minecraft/deeperworld/synchronization/Updaters.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/synchronization/Updaters.kt
@@ -7,6 +7,7 @@ import nl.rutgerkok.blocklocker.BlockLockerPlugin
 import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.block.Block
+import org.bukkit.block.BlockState
 import org.bukkit.block.Sign
 import org.bukkit.inventory.ItemStack
 import org.bukkit.util.Vector
@@ -15,6 +16,14 @@ internal val blockLocker: BlockLockerPlugin by lazy { BlockLockerAPIv2.getPlugin
 
 internal val copyBlockData = { original: Block, corresponding: Block ->
     corresponding.blockData = original.blockData.clone()
+}
+
+//TODO make a clean way for some basic stuff like this to be used for all the listeners
+internal fun List<BlockState>.copyBlocks() = forEach { it.copyBlock() }
+internal fun BlockState.copyBlock() = updateCorrespondingBlock(location, copyBlockData)
+internal fun List<BlockState>.updateBlocks() = forEach { it.updateBlock() }
+internal fun BlockState.updateBlock() = updateCorrespondingBlock(location) { _, corresponding ->
+    corresponding.blockData = this.blockData
 }
 
 internal fun updateMaterial(material: Material) = { _: Block, corr: Block -> corr.type = material }


### PR DESCRIPTION
Add listeners for section sync for crops and multi-part blocks like doors or beds.

~~There is currently an easy duplication glitch for any double blocks. If you break the top part of a door or bed, the drops appear on both sections. The only fix would have to be through a physics update event which can be fired thousands of times per second and I think checking blocks between sections isn't performant enough to deal with that.~~ (removed this event listener for now)

Can't think of any double blocks that would cause issues if duped, but I'd definitely want to hear more opinions as to whether or not this is a big enough issue.

Also, might be worth cleaning up some of the functions in Updaters.kt but I don't really want to do upkeep on DeeperWorld right now if DeepestWorld is getting somewhere :p