### PR TITLE
Move things into a shared gradle script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,15 +7,10 @@ plugins {
     id 'io.github.0ffz.github-packages'
 }
 
+apply from: 'https://raw.githubusercontent.com/MineInAbyss/shared-gradle/master/common.gradle'
+
 group 'com.derongan.minecraft'
-version pluginVersion
-
-if (project.hasProperty("buildNo")) version += ".$buildNo"
-
-java {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    withSourcesJar()
-}
+version plugin_version
 
 repositories {
     mavenCentral()
@@ -24,6 +19,16 @@ repositories {
     maven { url 'http://www.rutgerkok.nl/repo' }
     maven githubPackage.invoke("MineInAbyss/Idofront")
     maven githubPackage.invoke("rutgerkok/BlockLocker")
+}
+
+dependencies {
+    compileOnly "org.spigotmc:spigot-api:$server_version"
+    compileOnly 'nl.rutgerkok:blocklocker:1.6.2-SNAPSHOT'
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+    implementation 'com.mineinabyss:idofront:0.3.1+'
+
+    testImplementation 'junit:junit:4.12'
 }
 
 publishing {
@@ -37,22 +42,6 @@ publishing {
     }
 }
 
-dependencies {
-    compileOnly "org.spigotmc:spigot-api:$server_version"
-    compileOnly 'nl.rutgerkok:blocklocker:1.6.2-SNAPSHOT'
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-
-    implementation 'com.mineinabyss:idofront:0.3.1+'
-
-    testImplementation 'junit:junit:4.12'
-}
-
-import org.apache.tools.ant.filters.ReplaceTokens
-
-processResources {
-    filter ReplaceTokens, tokens: [version: version]
-}
-
 shadowJar {
     getArchiveClassifier().set(null)
     relocate 'com.mineinabyss.idofront', "${project.group}.${project.name}.idofront"
@@ -60,16 +49,6 @@ shadowJar {
     minimize()
 }
 build.dependsOn shadowJar
-
-//Move into plugins folder
-if (project.hasProperty("plugin_path") && plugin_path) {
-    println("Copying to plugin directory $plugin_path")
-    task copyJar(type: Copy) {
-        from shadowJar // here it automatically reads jar file produced from jar task
-        into plugin_path
-    }
-    build.dependsOn copyJar
-}
 
 compileKotlin { kotlinOptions { jvmTarget = "1.8" } }
 compileTestKotlin { kotlinOptions { jvmTarget = "1.8" } }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=0.1.4-alpha
+plugin_version=0.1.4-alpha
 kotlin_version=1.4.0
 server_version=1.16.2-R0.1-SNAPSHOT
 #toggle composite builds

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: DeeperWorld
-version: @version@
+version: @plugin_version@
 main: com.derongan.minecraft.deeperworld.DeeperWorld
 authors: [Derongan]
 api-version: '1.16'


### PR DESCRIPTION
Using gradle's [script plugin](https://docs.gradle.org/current/userguide/plugins.html#sec:script_plugins) feature to reuse code between our buildscripts, from a repo hosted on GitHub.

Some things the script over on [MineInAbyss/shared-gradle](https://github.com/MineInAbyss/shared-gradle/blob/master/common.gradle) standardizes between plugins:
- Set Java source compatibility to 1.8, and publish with sources jar
- `System.getenv("GITHUB_RUN_NUMBER")` to get the run number for actions instead of passing another property within the workflow
- Use plugin_version as the property name for the plugin version
- ReplaceTokens for plugin_version
- Copyjar task, with the print statement moved into a doLast block, so it only prints when the task actually finishes

### Other considerations

- We can link to specific commits of the file instead of the latest version like I did here, but it seems more convenient to be able to update everything everywhere without unnecessary commits. We'll probably barely be touching the script, but I'd like to hear others' opinions on this.
