### PR TITLE
Fix section teleport bugs with entities, use new style guide for all files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
     maven { url 'https://oss.sonatype.org/content/groups/public/' }
     maven { url 'http://www.rutgerkok.nl/repo' }
     maven { url 'http://nexus.okkero.com/repository/maven-releases/' } //Skedule
+    maven { url "https://repo.dmulloy2.net/nexus/repository/public/" }
     maven githubPackage.invoke("MineInAbyss/Idofront")
     maven githubPackage.invoke("rutgerkok/BlockLocker")
     maven githubPackage.invoke("MineInAbyss/KotlinSpice")
@@ -30,6 +31,7 @@ dependencies {
     compileOnly 'nl.rutgerkok:blocklocker:1.6.2-SNAPSHOT'
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     compileOnly "org.cultofclang.minecraft:kotlinspice:$kotlin_version+"
+    compileOnly "com.comphenix.protocol:ProtocolLib:4.5.0"
 
     implementation 'com.mineinabyss:idofront:0.3.27'
 

--- a/src/main/java/com/derongan/minecraft/deeperworld/DeeperWorld.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/DeeperWorld.kt
@@ -1,21 +1,25 @@
 package com.derongan.minecraft.deeperworld
 
+import com.comphenix.protocol.ProtocolLibrary
+import com.comphenix.protocol.ProtocolManager
 import com.derongan.minecraft.deeperworld.config.DeeperConfig
 import com.derongan.minecraft.deeperworld.listeners.MovementListener
 import com.derongan.minecraft.deeperworld.listeners.PlayerListener
 import com.derongan.minecraft.deeperworld.player.FallingDamageManager
-import com.derongan.minecraft.deeperworld.services.PlayerManager
 import com.derongan.minecraft.deeperworld.player.PlayerManagerImpl
-import com.derongan.minecraft.deeperworld.synchronization.SectionSyncListener
+import com.derongan.minecraft.deeperworld.services.PlayerManager
 import com.derongan.minecraft.deeperworld.services.WorldManager
 import com.derongan.minecraft.deeperworld.synchronization.ContainerSyncListener
 import com.derongan.minecraft.deeperworld.synchronization.ExploitPreventionListener
+import com.derongan.minecraft.deeperworld.synchronization.SectionSyncListener
 import com.derongan.minecraft.deeperworld.world.WorldManagerImpl
 import com.mineinabyss.idofront.commands.execution.ExperimentalCommandDSL
 import com.mineinabyss.idofront.plugin.registerEvents
 import com.mineinabyss.idofront.plugin.registerService
 import com.okkero.skedule.schedule
 import org.bukkit.plugin.java.JavaPlugin
+
+val protocolManager: ProtocolManager = ProtocolLibrary.getProtocolManager()
 
 class DeeperWorld : JavaPlugin() {
     @ExperimentalCommandDSL
@@ -28,11 +32,11 @@ class DeeperWorld : JavaPlugin() {
 
         registerService<PlayerManager>(PlayerManagerImpl())
         registerEvents(
-                MovementListener,
-                PlayerListener,
-                SectionSyncListener,
-                ExploitPreventionListener,
-                ContainerSyncListener
+            MovementListener,
+            PlayerListener,
+            SectionSyncListener,
+            ExploitPreventionListener,
+            ContainerSyncListener
         )
 
         //register command executor

--- a/src/main/java/com/derongan/minecraft/deeperworld/datastructures/Tree.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/datastructures/Tree.kt
@@ -6,14 +6,14 @@ import org.bukkit.entity.Entity
 /**
  * A generic tree structure implementation.
  */
-class TreeNode<T>(val value : T){
-    var parent : TreeNode<T>? = null
-    var children : MutableList<TreeNode<T>> = mutableListOf()
+class TreeNode<T>(val value: T) {
+    var parent: TreeNode<T>? = null
+    var children: MutableList<TreeNode<T>> = mutableListOf()
 
     /**
      * Add a node as the child of this node.
      */
-    fun addChild(node : TreeNode<T>){
+    fun addChild(node: TreeNode<T>) {
         children.add(node)
         node.parent = this
     }
@@ -21,36 +21,49 @@ class TreeNode<T>(val value : T){
     /**
      * Apply the given function to each node in the tree.
      */
-    fun applyAll(applyFun : (TreeNode<T>) -> Unit){
+    fun applyAll(applyFun: (TreeNode<T>) -> Unit) {
         applyFun(this)
-        children.forEach{child -> child.applyAll(applyFun)}
+        children.forEach { child -> child.applyAll(applyFun) }
     }
 
     /**
      * Get a list of nodes in the tree that satisfy the given condition.
      */
-    fun where(condition : (TreeNode<T>) -> Boolean) : List<TreeNode<T>>{
-        mutableListOf<TreeNode<T>>().let{ returnList ->
-            if(condition(this)){
+    fun where(condition: (TreeNode<T>) -> Boolean): List<TreeNode<T>> {
+        mutableListOf<TreeNode<T>>().let { returnList ->
+            if (condition(this)) {
                 returnList.add(this)
             }
 
-            children.forEach{returnList.addAll(it.where(condition))}
+            children.forEach { returnList.addAll(it.where(condition)) }
+
+            return returnList
+        }
+    }
+
+    /**
+     * Get the values of all the nodes in the tree
+     */
+    fun values(): List<T> {
+        mutableListOf<T>().let { returnList ->
+            returnList.add(value)
+
+            children.forEach { returnList.addAll(it.values()) }
 
             return returnList
         }
     }
 }
 
-class VehicleTree(rootVehicle : Entity){
+class VehicleTree(rootVehicle: Entity) {
     val root = TreeNode<Entity>(rootVehicle)
 
-    init{
+    init {
         addPassengerChildren(root)
     }
 
-    private fun addPassengerChildren(node : TreeNode<Entity>){
-        node.value.passengers.forEach{ passenger ->
+    private fun addPassengerChildren(node: TreeNode<Entity>) {
+        node.value.passengers.forEach { passenger ->
             TreeNode<Entity>(passenger).let {
                 node.addChild(it)
                 addPassengerChildren(it)

--- a/src/main/java/com/derongan/minecraft/deeperworld/event/PlayerAscendEvent.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/event/PlayerAscendEvent.kt
@@ -5,9 +5,9 @@ import org.bukkit.entity.Player
 import org.bukkit.event.HandlerList
 
 class PlayerAscendEvent(
-        player: Player,
-        fromSection: Section,
-        toSection: Section
+    player: Player,
+    fromSection: Section,
+    toSection: Section
 ) : PlayerChangeSectionEvent(player, fromSection, toSection) {
     override fun getHandlers() = handlerList
 

--- a/src/main/java/com/derongan/minecraft/deeperworld/event/PlayerChangeSectionEvent.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/event/PlayerChangeSectionEvent.kt
@@ -7,9 +7,9 @@ import org.bukkit.event.HandlerList
 import org.bukkit.event.player.PlayerEvent
 
 abstract class PlayerChangeSectionEvent(
-        player: Player,
-        val fromSection: Section,
-        val toSection: Section
+    player: Player,
+    val fromSection: Section,
+    val toSection: Section
 ) : PlayerEvent(player), Cancellable {
     private var cancelled = false
 

--- a/src/main/java/com/derongan/minecraft/deeperworld/event/PlayerDescendEvent.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/event/PlayerDescendEvent.kt
@@ -5,9 +5,9 @@ import org.bukkit.entity.Player
 import org.bukkit.event.HandlerList
 
 class PlayerDescendEvent(
-        player: Player,
-        fromSection: Section,
-        toSection: Section
+    player: Player,
+    fromSection: Section,
+    toSection: Section
 ) : PlayerChangeSectionEvent(player, fromSection, toSection) {
     override fun getHandlers() = handlerList
 

--- a/src/main/java/com/derongan/minecraft/deeperworld/extensions/DeeperWorldExtensions.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/extensions/DeeperWorldExtensions.kt
@@ -27,7 +27,11 @@ internal fun Entity.getPassengersRecursive(): List<Entity> {
 }
 
 internal fun Player.getLeashedEntities(): List<LivingEntity> {
-    return getNearbyEntities(20.0, 20.0, 20.0) // Max leashed entity range is 10 blocks, therefore these parameter values
-            .filterIsInstance<LivingEntity>()
-            .filter { it.isLeashed && it.leashHolder == this }
+    return getNearbyEntities(
+        20.0,
+        20.0,
+        20.0
+    ) // Max leashed entity range is 10 blocks, therefore these parameter values
+        .filterIsInstance<LivingEntity>()
+        .filter { it.isLeashed && it.leashHolder == this }
 }

--- a/src/main/java/com/derongan/minecraft/deeperworld/extensions/DeeperWorldExtensions.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/extensions/DeeperWorldExtensions.kt
@@ -27,11 +27,8 @@ internal fun Entity.getPassengersRecursive(): List<Entity> {
 }
 
 internal fun Player.getLeashedEntities(): List<LivingEntity> {
-    return getNearbyEntities(
-        20.0,
-        20.0,
-        20.0
-    ) // Max leashed entity range is 10 blocks, therefore these parameter values
+    // Max leashed entity range is 10 blocks, therefore these parameter values
+    return getNearbyEntities(20.0, 20.0, 20.0)
         .filterIsInstance<LivingEntity>()
         .filter { it.isLeashed && it.leashHolder == this }
 }

--- a/src/main/java/com/derongan/minecraft/deeperworld/listeners/MovementListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/listeners/MovementListener.kt
@@ -1,10 +1,11 @@
 package com.derongan.minecraft.deeperworld.listeners
 
+import com.comphenix.protocol.PacketType
+import com.comphenix.protocol.events.PacketAdapter
+import com.comphenix.protocol.events.PacketEvent
+import com.derongan.minecraft.deeperworld.*
 import com.derongan.minecraft.deeperworld.config.DeeperConfig
-import com.derongan.minecraft.deeperworld.MinecraftConstants
-import com.derongan.minecraft.deeperworld.Permissions
 import com.derongan.minecraft.deeperworld.datastructures.VehicleTree
-import com.derongan.minecraft.deeperworld.deeperWorld
 import com.derongan.minecraft.deeperworld.event.PlayerAscendEvent
 import com.derongan.minecraft.deeperworld.event.PlayerDescendEvent
 import com.derongan.minecraft.deeperworld.extensions.getLeashedEntities
@@ -20,12 +21,15 @@ import com.okkero.skedule.schedule
 import org.bukkit.GameMode
 import org.bukkit.Location
 import org.bukkit.attribute.Attribute
+import org.bukkit.entity.EntityType
+import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerMoveEvent
 import org.bukkit.event.vehicle.VehicleMoveEvent
+import org.bukkit.util.Vector
 
 object MovementListener : Listener {
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
@@ -50,11 +54,21 @@ object MovementListener : Listener {
         val current = WorldManager.getSectionFor(player.location) ?: let {
             //damage players outside of sections
             if (!DeeperConfig.data.damageExcludedWorlds.contains(player.location.world)
-                    && DeeperConfig.data.damageOutsideSections > 0.0
-                    && (player.gameMode == GameMode.SURVIVAL || player.gameMode == GameMode.ADVENTURE)) {
+                && DeeperConfig.data.damageOutsideSections > 0.0
+                && (player.gameMode == GameMode.SURVIVAL || player.gameMode == GameMode.ADVENTURE)
+            ) {
                 player.damage(0.01) //give a damage effect
-                player.health = (player.health - DeeperConfig.data.damageOutsideSections / 10).coerceIn(0.0, player.getAttribute(Attribute.GENERIC_MAX_HEALTH)?.value) //ignores armor
-                player.sendTitle("&cYou are not in a managed section".color(), "&7You will take damage upon moving!".color(), 0, 20, 10)
+                player.health = (player.health - DeeperConfig.data.damageOutsideSections / 10).coerceIn(
+                    0.0,
+                    player.getAttribute(Attribute.GENERIC_MAX_HEALTH)?.value
+                ) //ignores armor
+                player.sendTitle(
+                    "&cYou are not in a managed section".color(),
+                    "&7You will take damage upon moving!".color(),
+                    0,
+                    20,
+                    10
+                )
             }
             return
         }
@@ -64,14 +78,20 @@ object MovementListener : Listener {
 
         val inSpectator = player.gameMode == GameMode.SPECTATOR
 
-        fun tpIfAbleTo(key: SectionKey, tpFun: (Player, Location, Section, Section) -> Unit, boundaryCheck: (y: Double, shared: Int) -> Boolean, pushVelocity: Double) {
+        fun tpIfAbleTo(
+            key: SectionKey,
+            tpFun: (Player, Location, Section, Section) -> Unit,
+            boundaryCheck: (y: Double, shared: Int) -> Boolean,
+            pushVelocity: Double
+        ) {
             val toSection = key.section ?: return
             val overlap = current.overlapWith(toSection) ?: return
             val correspondingPos = to.getCorrespondingLocation(current, toSection) ?: return
 
             if (boundaryCheck(to.y, overlap)) {
                 if (!toSection.region.contains(correspondingPos.blockX, correspondingPos.blockZ)
-                        || !inSpectator && correspondingPos.block.type.isSolid)
+                    || !inSpectator && correspondingPos.block.type.isSolid
+                )
                     player.velocity = player.velocity.setY(pushVelocity)
                 else
                     tpFun(player, to, current, toSection)
@@ -79,8 +99,18 @@ object MovementListener : Listener {
         }
 
         when {
-            changeY > 0.0 -> tpIfAbleTo(current.aboveKey, MovementListener::ascend, { y, shared -> y > MinecraftConstants.WORLD_HEIGHT - .3 * shared }, -0.4)
-            changeY < 0.0 -> tpIfAbleTo(current.belowKey, MovementListener::descend, { y, shared -> y < .3 * shared }, 0.4)
+            changeY > 0.0 -> tpIfAbleTo(
+                current.aboveKey,
+                MovementListener::ascend,
+                { y, shared -> y > MinecraftConstants.WORLD_HEIGHT - .3 * shared },
+                -0.4
+            )
+            changeY < 0.0 -> tpIfAbleTo(
+                current.belowKey,
+                MovementListener::descend,
+                { y, shared -> y < .3 * shared },
+                0.4
+            )
         }
     }
 
@@ -132,13 +162,95 @@ object MovementListener : Listener {
                 }
             }
 
+            // If the vehicleTree contains a minecart, teleporting the player across worlds within the same tick
+            // as removing the passenger throws a "Removing ticking entity!" exception.
+            // Delay the teleportation by 1 tick in this case.
+            if (vehicleTree.root.where { it.value.type == EntityType.MINECART }.isNotEmpty()) {
+                deeperWorld.schedule {
+                    waitFor(1)
+
+                    player.teleport(newLoc)
+
+                    protocolManager.addPacketListener(
+                        SectionTeleportPacketAdapter(
+                            player,
+                            oldLeashedEntities,
+                            oldFallDistance,
+                            oldVelocity,
+                            vehicleTree
+                        )
+                    )
+                }
+            } else {
+                player.teleport(newLoc)
+
+                protocolManager.addPacketListener(
+                    SectionTeleportPacketAdapter(
+                        player,
+                        oldLeashedEntities,
+                        oldFallDistance,
+                        oldVelocity,
+                        vehicleTree
+                    )
+                )
+            }
+        } else {
+            val oldFallDistance = player.fallDistance
+            val oldVelocity = player.velocity
+
             player.teleport(newLoc)
 
-            deeperWorld.schedule {
-                waitFor(DeeperConfig.data.entityTeleportDelay)
+            player.fallDistance = oldFallDistance
+            player.velocity = oldVelocity
 
-                vehicleTree.root.applyAll {
-                    it.value.teleport(player)
+            if (oldLeashedEntities.isNotEmpty()) {
+                protocolManager.addPacketListener(
+                    SectionTeleportPacketAdapter(
+                        player,
+                        oldLeashedEntities,
+                        oldFallDistance,
+                        oldVelocity
+                    )
+                )
+            }
+        }
+    }
+}
+
+/**
+ * This PacketAdapter serves to teleport entities with the player at the correct time
+ * (after the client sends a POSITION or POSITION_LOOK packet). This circumvents the client side rendering bug
+ * when entities are teleported with the player in the same tick.
+ *
+ * TODO: Remove listener if a player disconnects before sending a POSITION or POSITION_LOOK packet
+ */
+class SectionTeleportPacketAdapter(
+    private val player: Player,
+    private val oldLeashedEntities: List<LivingEntity>,
+    private val oldFallDistance: Float,
+    private val oldVelocity: Vector,
+    private val vehicleTree: VehicleTree? = null
+) : PacketAdapter(deeperWorld, PacketType.Play.Client.POSITION, PacketType.Play.Client.POSITION_LOOK) {
+    override fun onPacketReceiving(event: PacketEvent) {
+        if (event.player != player) return
+
+        protocolManager.removePacketListener(this)
+
+        deeperWorld.schedule {
+            waitFor(1)
+
+            oldLeashedEntities.toSet().forEach {
+                if (it == player) return@forEach
+
+                it.teleport(player)
+                it.setLeashHolder(player)
+            }
+
+            if (vehicleTree != null) {
+                vehicleTree.root.values().toSet().forEach {
+                    if (it == player) return@forEach
+
+                    it.teleport(player)
                 }
 
                 vehicleTree.root.applyAll { vehicleNode ->
@@ -147,28 +259,8 @@ object MovementListener : Listener {
                     }
                 }
 
-                rootVehicle.fallDistance = oldFallDistance
-                rootVehicle.velocity = oldVelocity
-
-                oldLeashedEntities.forEach { leashEntity ->
-                    leashEntity.teleport(player)
-                    leashEntity.setLeashHolder(player)
-                }
-            }
-        } else {
-            val fallDistance = player.fallDistance
-            val oldVelocity = player.velocity
-            player.teleport(newLoc)
-            player.fallDistance = fallDistance
-            player.velocity = oldVelocity
-
-            deeperWorld.schedule {
-                waitFor(DeeperConfig.data.entityTeleportDelay)
-
-                oldLeashedEntities.forEach { leashEntity ->
-                    leashEntity.teleport(player)
-                    leashEntity.setLeashHolder(player)
-                }
+                vehicleTree.root.value.fallDistance = oldFallDistance
+                vehicleTree.root.value.velocity = oldVelocity
             }
         }
     }

--- a/src/main/java/com/derongan/minecraft/deeperworld/listeners/MovementListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/listeners/MovementListener.kt
@@ -58,16 +58,12 @@ object MovementListener : Listener {
                 && (player.gameMode == GameMode.SURVIVAL || player.gameMode == GameMode.ADVENTURE)
             ) {
                 player.damage(0.01) //give a damage effect
-                player.health = (player.health - DeeperConfig.data.damageOutsideSections / 10).coerceIn(
-                    0.0,
-                    player.getAttribute(Attribute.GENERIC_MAX_HEALTH)?.value
-                ) //ignores armor
+                player.health = (player.health - DeeperConfig.data.damageOutsideSections / 10)
+                    .coerceIn(0.0, player.getAttribute(Attribute.GENERIC_MAX_HEALTH)?.value) //ignores armor
                 player.sendTitle(
                     "&cYou are not in a managed section".color(),
                     "&7You will take damage upon moving!".color(),
-                    0,
-                    20,
-                    10
+                    0, 20, 10
                 )
             }
             return
@@ -162,26 +158,11 @@ object MovementListener : Listener {
                 }
             }
 
-            // If the vehicleTree contains a minecart, teleporting the player across worlds within the same tick
-            // as removing the passenger throws a "Removing ticking entity!" exception.
-            // Delay the teleportation by 1 tick in this case.
-            if (vehicleTree.root.where { it.value.type == EntityType.MINECART }.isNotEmpty()) {
-                deeperWorld.schedule {
-                    waitFor(1)
+            // Delay the teleportation by 1 tick after passenger removal to avoid occasional
+            // "Removing ticking entity!" exceptions.
+            deeperWorld.schedule {
+                waitFor(1)
 
-                    player.teleport(newLoc)
-
-                    protocolManager.addPacketListener(
-                        SectionTeleportPacketAdapter(
-                            player,
-                            oldLeashedEntities,
-                            oldFallDistance,
-                            oldVelocity,
-                            vehicleTree
-                        )
-                    )
-                }
-            } else {
                 player.teleport(newLoc)
 
                 protocolManager.addPacketListener(

--- a/src/main/java/com/derongan/minecraft/deeperworld/listeners/PlayerListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/listeners/PlayerListener.kt
@@ -17,8 +17,9 @@ object PlayerListener : Listener {
     fun onPlayerTeleport(event: PlayerTeleportEvent) {
         val (player, _, to, cause) = event
         if (player.gameMode == SURVIVAL
-                && (cause == ENDER_PEARL || cause == CHORUS_FRUIT)
-                && to?.section == null) {
+            && (cause == ENDER_PEARL || cause == CHORUS_FRUIT)
+            && to?.section == null
+        ) {
             event.isCancelled = true
         }
     }

--- a/src/main/java/com/derongan/minecraft/deeperworld/player/PlayerManagerImpl.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/player/PlayerManagerImpl.kt
@@ -8,7 +8,7 @@ class PlayerManagerImpl : PlayerManager {
     private val playerMap = mutableMapOf<UUID, Boolean>()
 
     override fun playerCanTeleport(player: Player): Boolean =
-            playerMap.getOrDefault(player.uniqueId, true)
+        playerMap.getOrDefault(player.uniqueId, true)
 
     override fun setPlayerCanTeleport(player: Player, canTeleport: Boolean) {
         playerMap[player.uniqueId] = canTeleport

--- a/src/main/java/com/derongan/minecraft/deeperworld/synchronization/ContainerSyncListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/synchronization/ContainerSyncListener.kt
@@ -38,16 +38,18 @@ object ContainerSyncListener : Listener {
             val linkedBlock = loc.getCorrespondingLocation(section, linkedSection)?.block ?: return
 
             if (DeeperContext.isBlockLockerLoaded) {
-                fun updateProtection(block: Block) = blockLocker.protectionFinder.findProtection(block, SearchMode.ALL).ifPresent {
-                    it.signs.forEach { sign -> sign.location.sync(signUpdater()) }
-                }
+                fun updateProtection(block: Block) =
+                    blockLocker.protectionFinder.findProtection(block, SearchMode.ALL).ifPresent {
+                        it.signs.forEach { sign -> sign.location.sync(signUpdater()) }
+                    }
                 updateProtection(linkedBlock)
                 updateProtection(clicked)
 
                 //allow chest protection signs to be placed
                 if (player.inventory.itemInMainHand.type.name.contains("SIGN")
-                        || !BlockLockerAPIv2.isAllowed(player, clicked, true)
-                        || !BlockLockerAPIv2.isAllowed(player, linkedBlock, true))
+                    || !BlockLockerAPIv2.isAllowed(player, clicked, true)
+                    || !BlockLockerAPIv2.isAllowed(player, linkedBlock, true)
+                )
                     return
             }
 

--- a/src/main/java/com/derongan/minecraft/deeperworld/synchronization/ExploitPreventionListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/synchronization/ExploitPreventionListener.kt
@@ -6,7 +6,7 @@ import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockPistonExtendEvent
 import org.bukkit.event.block.BlockPistonRetractEvent
 
-object ExploitPreventionListener: Listener {
+object ExploitPreventionListener : Listener {
     /** Disables pistons extending if they are in the overlap of two sections */
     @EventHandler
     fun onPistonExtendEvent(event: BlockPistonExtendEvent) {

--- a/src/main/java/com/derongan/minecraft/deeperworld/synchronization/SectionSyncListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/synchronization/SectionSyncListener.kt
@@ -32,7 +32,7 @@ object SectionSyncListener : Listener {
             //if breaking from bottom container, drop items stored in top container here
             if (state is Container && original.location.y > corr.location.y) {
                 val corrInv = state.inventory
-                if(state is ShulkerBox) {
+                if (state is ShulkerBox) {
                     e.isDropItems = false
                     //TODO maybe create our own event that gets called from here
                     corr.drops.dropItems(original.location, noVelocity = false)
@@ -55,7 +55,7 @@ object SectionSyncListener : Listener {
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
     fun syncBlockPlace(blockPlaceEvent: BlockPlaceEvent) {
         blockPlaceEvent.block.sync { original, corr ->
-            if(original.type.name.contains("SHULKER")) {
+            if (original.type.name.contains("SHULKER")) {
                 blockPlaceEvent.isCancelled = true
                 blockPlaceEvent.player.error("Shulkers are disabled near section changes due to item loss bugs.")
                 return@sync
@@ -79,26 +79,26 @@ object SectionSyncListener : Listener {
 
     @EventHandler
     fun syncWaterEmpty(event: PlayerBucketEmptyEvent) =
-            event.block.sync { orig, corr ->
-                val data = corr.blockData
-                if (data is Waterlogged) {
-                    data.isWaterlogged = true
-                    corr.blockData = data
+        event.block.sync { orig, corr ->
+            val data = corr.blockData
+            if (data is Waterlogged) {
+                data.isWaterlogged = true
+                corr.blockData = data
 //                    corr.state.update(true, true) //TODO we need to send a block update somehow and this doesn't work
-                } else
-                    updateMaterial(Material.WATER)(orig, corr)
-            }
+            } else
+                updateMaterial(Material.WATER)(orig, corr)
+        }
 
     @EventHandler
     fun syncWaterFill(event: PlayerBucketFillEvent) =
-            event.block.sync { orig, corr ->
-                val data = corr.blockData
-                if (data is Waterlogged) {
-                    data.isWaterlogged = false
-                    corr.blockData = data
-                } else
-                    updateMaterial(Material.AIR)(orig, corr)
-            }
+        event.block.sync { orig, corr ->
+            val data = corr.blockData
+            if (data is Waterlogged) {
+                data.isWaterlogged = false
+                corr.blockData = data
+            } else
+                updateMaterial(Material.AIR)(orig, corr)
+        }
 
     /** Synchronize explosions */
     @EventHandler

--- a/src/main/java/com/derongan/minecraft/deeperworld/synchronization/Updaters.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/synchronization/Updaters.kt
@@ -18,10 +18,11 @@ internal fun copyBlockData(original: Block, corresponding: Block) {
 
 internal fun updateMaterial(material: Material) = { _: Block, corr: Block -> corr.type = material }
 
-internal fun Block.sync(updater: (original: Block, corresponding: Block) -> Unit = ::copyBlockData) = location.sync(updater)
+internal fun Block.sync(updater: (original: Block, corresponding: Block) -> Unit = ::copyBlockData) =
+    location.sync(updater)
 
 internal inline fun Location.sync(
-        updater: (original: Block, corresponding: Block, section: Section, corrSection: Section) -> Unit
+    updater: (original: Block, corresponding: Block, section: Section, corrSection: Section) -> Unit
 ) {
     if (!inSectionOverlap) return //ensure blocks don't get altered when we are outside of the corresponding region
     val section = section ?: return
@@ -31,7 +32,7 @@ internal inline fun Location.sync(
 }
 
 internal inline fun Location.sync(updater: (original: Block, corresponding: Block) -> Unit = ::copyBlockData) =
-        sync { original, corresponding, _, _ -> updater(original, corresponding) }
+    sync { original, corresponding, _, _ -> updater(original, corresponding) }
 
 internal fun signUpdater(lines: Array<String>? = null) = { original: Block, corresponding: Block ->
     copyBlockData(original, corresponding)
@@ -48,5 +49,7 @@ internal fun signUpdater(lines: Array<String>? = null) = { original: Block, corr
 
 internal fun Collection<ItemStack?>.dropItems(loc: Location, noVelocity: Boolean) {
     val spawnLoc = loc.clone().add(0.5, if (noVelocity) 1.0 else 0.0, 0.5)
-    filterNotNull().forEach { loc.world?.dropItem(spawnLoc, it).apply { if (noVelocity) this?.velocity = Vector(0, 0, 0) } }
+    filterNotNull().forEach {
+        loc.world?.dropItem(spawnLoc, it).apply { if (noVelocity) this?.velocity = Vector(0, 0, 0) }
+    }
 }

--- a/src/main/java/com/derongan/minecraft/deeperworld/world/WorldManagerImpl.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/world/WorldManagerImpl.kt
@@ -15,10 +15,10 @@ class WorldManagerImpl(config: FileConfiguration) : WorldManager {
 
 
     override fun registerSection(name: String, section: Section): SectionKey =
-            registerInternal(CustomSectionKey(name), section)
+        registerInternal(CustomSectionKey(name), section)
 
     override fun registerSection(sectionKey: SectionKey, section: Section): SectionKey =
-            registerInternal(sectionKey, section)
+        registerInternal(sectionKey, section)
 
     private fun registerInternal(key: SectionKey, section: Section): SectionKey {
         if (sectionMap.containsKey(key)) throw RuntimeException("Bruh") //TODO change to checked exception
@@ -33,7 +33,7 @@ class WorldManagerImpl(config: FileConfiguration) : WorldManager {
     }
 
     override fun getSectionFor(x: Int, z: Int, world: World): Section? = //TODO consider performance
-            sectionMap.values.firstOrNull { it.world == world && it.region.contains(x, z) }
+        sectionMap.values.firstOrNull { it.world == world && it.region.contains(x, z) }
 
     override fun getSectionFor(key: SectionKey) = sectionMap[key]
     override fun getSectionFor(key: String) = sectionMap[CustomSectionKey(key)]

--- a/src/main/java/com/derongan/minecraft/deeperworld/world/section/Section.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/world/section/Section.kt
@@ -25,11 +25,11 @@ import org.bukkit.util.Vector
  */
 @Serializable
 data class Section(
-        val name: String? = null,
-        val region: Region,
-        val world: World,
-        @SerialName("refTop") private val _refTop: Vector,
-        @SerialName("refBottom") private val _refBottom: Vector
+    val name: String? = null,
+    val region: Region,
+    val world: World,
+    @SerialName("refTop") private val _refTop: Vector,
+    @SerialName("refBottom") private val _refBottom: Vector
 ) {
     @Transient
     val referenceTop = _refTop.toLocation(world)
@@ -39,7 +39,7 @@ data class Section(
 
     @Transient
     val key: SectionKey = name?.let { AbstractSectionKey.CustomSectionKey(name) }
-            ?: AbstractSectionKey.InternalSectionKey()
+        ?: AbstractSectionKey.InternalSectionKey()
 
     @Transient
     internal var aboveKey: SectionKey = SectionKey.TERMINAL

--- a/src/main/java/com/derongan/minecraft/deeperworld/world/section/SectionUtils.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/world/section/SectionUtils.kt
@@ -47,7 +47,7 @@ val Location.correspondingLocation: Location?
  * @return A new location that corresponds to the original location
  */
 fun Location.getCorrespondingLocation(sectionA: Section, sectionB: Section): Location? {
-    if(!sectionA.isAdjacentTo(sectionB)) return null
+    if (!sectionA.isAdjacentTo(sectionB)) return null
 
     // We decide which two points we are translating between.
     val (fromSectionLoc, toSectionLoc) = when (sectionA.isOnTopOf(sectionB)) {
@@ -78,7 +78,7 @@ fun Location.sharedBetween(section: Section, otherSection: Section): Boolean {
 }
 
 fun Section.overlapWith(other: Section): Int? {
-    if(!isAdjacentTo(other)) return null
+    if (!isAdjacentTo(other)) return null
     // We decide which two points we are translating between.
     val (locA, locB) = when (isOnTopOf(other)) {
         true -> referenceBottom to other.referenceTop

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ authors: [Derongan]
 api-version: '1.16'
 description: A plugin for letting you create a deeper world. Or at least fake it.
 
-softdepend: [Multiverse-Core, BlockLocker, KotlinSpice]
+softdepend: [Multiverse-Core, BlockLocker, KotlinSpice, ProtocolLib]
 
 commands:
   sectionon:


### PR DESCRIPTION
In hindsight I should have probably made the fixes and style guide change two seperate commits.

The main code changes are in DeeperWorld.kt, Tree.kt and MovementListener.kt.