### PR TITLE
OoB Tp "permission"

### DIFF
--- a/src/main/java/com/derongan/minecraft/deeperworld/listeners/PlayerListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/listeners/PlayerListener.kt
@@ -1,5 +1,6 @@
 package com.derongan.minecraft.deeperworld.listeners
 
+import com.derongan.minecraft.deeperworld.services.canMoveSections
 import com.derongan.minecraft.deeperworld.world.section.section
 import com.mineinabyss.idofront.destructure.component1
 import com.mineinabyss.idofront.destructure.component2
@@ -16,9 +17,9 @@ object PlayerListener : Listener {
     @EventHandler
     fun onPlayerTeleport(event: PlayerTeleportEvent) {
         val (player, _, to, cause) = event
-        if (player.gameMode == SURVIVAL
-            && (cause == ENDER_PEARL || cause == CHORUS_FRUIT)
-            && to?.section == null
+        if ((player.gameMode == SURVIVAL
+                && (cause == ENDER_PEARL || cause == CHORUS_FRUIT)
+                && to?.section == null) && player.canMoveSections
         ) {
             event.isCancelled = true
         }

--- a/src/main/java/com/derongan/minecraft/deeperworld/listeners/PlayerListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/listeners/PlayerListener.kt
@@ -17,9 +17,10 @@ object PlayerListener : Listener {
     @EventHandler
     fun onPlayerTeleport(event: PlayerTeleportEvent) {
         val (player, _, to, cause) = event
-        if ((player.gameMode == SURVIVAL
-                && (cause == ENDER_PEARL || cause == CHORUS_FRUIT)
-                && to?.section == null) && player.canMoveSections
+        if (player.gameMode == SURVIVAL
+            && (cause == ENDER_PEARL || cause == CHORUS_FRUIT)
+            && to?.section == null
+            && player.canMoveSections
         ) {
             event.isCancelled = true
         }


### PR DESCRIPTION
Checks to see if player can tp between sections.
If /dw tp is set to off, player can tp with pearls and does not get affected by OoB damage.
Not sure if you want it as an actual permission but devboi