### PR TITLE
Disable epearl/chorus tp between sections to avoid exploit

### DIFF
--- a/src/main/java/com/derongan/minecraft/deeperworld/listeners/PlayerListener.kt
+++ b/src/main/java/com/derongan/minecraft/deeperworld/listeners/PlayerListener.kt
@@ -5,7 +5,8 @@ import com.derongan.minecraft.deeperworld.world.section.section
 import com.mineinabyss.idofront.destructure.component1
 import com.mineinabyss.idofront.destructure.component2
 import com.mineinabyss.idofront.destructure.component3
-import org.bukkit.GameMode
+import com.mineinabyss.idofront.messaging.error
+import org.bukkit.GameMode.ADVENTURE
 import org.bukkit.GameMode.SURVIVAL
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -17,11 +18,13 @@ object PlayerListener : Listener {
     @EventHandler
     fun onPlayerTeleport(event: PlayerTeleportEvent) {
         val (player, _, to, cause) = event
-        if (player.gameMode == SURVIVAL
+        if (
+            (player.gameMode == SURVIVAL || player.gameMode == ADVENTURE)
             && (cause == ENDER_PEARL || cause == CHORUS_FRUIT)
-            && to?.section == null
+            && (to.section != player.location.section || to.section == null)
             && player.canMoveSections
         ) {
+            player.error("Teleportation is disabled between Layers and Sections.")
             event.isCancelled = true
         }
     }


### PR DESCRIPTION
Since both BoneHurtingJuice and MiA depend on a y-change, the current implementation lets you bypass both and go from bottom to orth with no risk.
Ideally it would apply and stack curse corresponding to the altitude and amount of layers one went through

Meant as temporary until this someday is implemented to let players utilize these items