### PR TITLE
Update, fix and add more sync stuff

### DIFF
--- a/src/main/kotlin/com/mineinabyss/deeperworld/DeeperCommandExecutor.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/DeeperCommandExecutor.kt
@@ -6,6 +6,7 @@ import com.mineinabyss.deeperworld.config.DeeperConfig
 import com.mineinabyss.deeperworld.services.WorldManager
 import com.mineinabyss.deeperworld.services.canMoveSections
 import com.mineinabyss.deeperworld.synchronization.sync
+import com.mineinabyss.deeperworld.world.section.correspondingLocation
 import com.mineinabyss.deeperworld.world.section.correspondingSection
 import com.mineinabyss.deeperworld.world.section.getCorrespondingLocation
 import com.mineinabyss.deeperworld.world.section.section
@@ -41,6 +42,11 @@ class DeeperCommandExecutor : IdofrontCommandExecutor(), TabCompleter {
                 playerAction {
                     player.canMoveSections = state
                     sender.success("Automatic TP ${if (state) "enabled" else "disabled"} for ${player.name}")
+                }
+            }
+            "tpcorr" {
+                playerAction {
+                    player.teleport(player.location.correspondingLocation ?: return@playerAction)
                 }
             }
             ("layerinfo" / "linfo" / "info")(desc = "Gets information about a players section") {
@@ -106,7 +112,7 @@ class DeeperCommandExecutor : IdofrontCommandExecutor(), TabCompleter {
 
                                 val region = CuboidRegion(pos1, pos2)
                                 val clipboard = BlockArrayClipboard(region)
-                                val wep = WorldEditPlugin.getInstance().bukkitImplAdapter;
+                                val wep = WorldEditPlugin.getInstance().bukkitImplAdapter
                                 val weWorld: World = wep.adapt(player.world)
                                 val editSession: EditSession = WorldEdit.getInstance().newEditSessionBuilder()
                                         .world(weWorld)
@@ -121,7 +127,7 @@ class DeeperCommandExecutor : IdofrontCommandExecutor(), TabCompleter {
                                     ?: error("Corresponding Location not found")
 
                                 val offset = if (pos2.y < 0) pos2.y else 0
-                                TaskManager.IMP.taskNowAsync {
+                                TaskManager.taskManager().taskNowAsync {
                                     player.success("Blocks syncing...")
                                     editSession.use { editSession ->
                                         // Copy

--- a/src/main/kotlin/com/mineinabyss/deeperworld/Permissions.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/Permissions.kt
@@ -1,5 +1,5 @@
 package com.mineinabyss.deeperworld
 
 object Permissions {
-    const val CHANGE_SECTION_PERMISSION = "deeperworld.changesection"
+    const val ADMIN_PERMISSION = "deeperworld.admin"
 }

--- a/src/main/kotlin/com/mineinabyss/deeperworld/listeners/MovementListener.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/listeners/MovementListener.kt
@@ -18,7 +18,7 @@ object MovementListener : Listener {
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     fun PlayerMoveEvent.move() {
-        if (player.hasPermission(Permissions.CHANGE_SECTION_PERMISSION) && player.canMoveSections) {
+        if (player.hasPermission(Permissions.ADMIN_PERMISSION) && player.canMoveSections) {
             MovementHandler.handleMovement(player, from, to)
         }
     }
@@ -27,7 +27,7 @@ object MovementListener : Listener {
     fun VehicleMoveEvent.move() {
         val players = vehicle.getPassengersRecursive().filterIsInstance<Player>()
 
-        players.firstOrNull { it.hasPermission(Permissions.CHANGE_SECTION_PERMISSION) && it.canMoveSections }?.let {
+        players.firstOrNull { it.hasPermission(Permissions.ADMIN_PERMISSION) && it.canMoveSections }?.let {
             MovementHandler.handleMovement(it, from, to)
         }
     }
@@ -36,7 +36,7 @@ object MovementListener : Listener {
     fun EntityMoveEvent.entityMove() {
         if (entity.getPassengersRecursive().isEmpty()) return
         entity.getPassengersRecursive().filterIsInstance<Player>()
-            .filter { rider -> rider.hasPermission(Permissions.CHANGE_SECTION_PERMISSION) && rider.canMoveSections }
+            .filter { rider -> rider.hasPermission(Permissions.ADMIN_PERMISSION) && rider.canMoveSections }
             .forEach { MovementHandler.handleMovement(it, from, to) }
     }
 }

--- a/src/main/kotlin/com/mineinabyss/deeperworld/movement/MovementHandler.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/movement/MovementHandler.kt
@@ -32,24 +32,21 @@ object MovementHandler {
                 }
             } ?: return
         } else {
-            applyOutOfBoundsDamage(player)
+            player.applyOutOfBoundsDamage()
         }
     }
 
     //TODO abstract this away. Should instead do out of bounds action if out of bounds.
-    private fun applyOutOfBoundsDamage(player: Player) {
+    private fun Player.applyOutOfBoundsDamage() {
         if (DeeperConfig.data.damageOutsideSections > 0.0
-            && player.location.world !in DeeperConfig.data.damageExcludedWorlds
-            && (player.gameMode == GameMode.SURVIVAL || player.gameMode == GameMode.ADVENTURE)
-            && player.location.world in (DeeperConfig.data.worlds)
+            && location.world !in DeeperConfig.data.damageExcludedWorlds
+            && (gameMode == GameMode.SURVIVAL || gameMode == GameMode.ADVENTURE)
+            && location.world in (DeeperConfig.data.worlds)
         ) {
-            player.damage(0.01) //give a damage effect
-            player.health = (player.health - DeeperConfig.data.damageOutsideSections / 10)
-                .coerceIn(
-                    0.0,
-                    player.getAttribute(Attribute.GENERIC_MAX_HEALTH)?.value
-                ) //ignores armor
-            player.showTitle(
+            damage(0.01) //give a damage effect
+            health = (health - DeeperConfig.data.damageOutsideSections / 10)
+                .coerceIn(0.0, getAttribute(Attribute.GENERIC_MAX_HEALTH)?.value) //ignores armor
+            showTitle(
                 Title.title(
                     "<red>You are not in a managed section".miniMsg(),
                     "<gray>You will take damage upon moving!".miniMsg(),

--- a/src/main/kotlin/com/mineinabyss/deeperworld/movement/TransitionTeleportHandler.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/movement/TransitionTeleportHandler.kt
@@ -95,14 +95,13 @@ class TransitionTeleportHandler(val player: Player, val from: Location, val to: 
 
     private fun Player.getLeashedEntities(): List<LivingEntity> {
         // Max leashed entity range is 10 blocks, therefore these parameter values
-        return getNearbyEntities(20.0, 20.0, 20.0)
-            .filterIsInstance<LivingEntity>()
+        return location.getNearbyEntitiesByType(LivingEntity::class.java, 20.0)
             .filter { it.isLeashed && it.leashHolder == this }
     }
 
     private fun Player.teleportWithSpectatorsAsync(loc: Location, thenRun: (Boolean) -> Unit) {
-        val nearbySpectators = getNearbyEntities(5.0, 5.0, 5.0)
-            .filterIsInstance<Player>()
+        val nearbySpectators =
+            location.getNearbyEntitiesByType(Player::class.java, 5.0)
             .filter { it.spectatorTarget == this }
 
         nearbySpectators.forEach {

--- a/src/main/kotlin/com/mineinabyss/deeperworld/synchronization/ExploitPreventionListener.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/synchronization/ExploitPreventionListener.kt
@@ -12,19 +12,18 @@ import org.bukkit.event.block.BlockPistonRetractEvent
 
 object ExploitPreventionListener : Listener {
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun BlockPistonExtendEvent.onPistonExtendEvent() {
         val corrBlock = block.location.correspondingLocation?.block ?: return
         val corrBlocks = mutableListOf<Block>()
 
         if (blocks.all { b -> !b.location.inSectionOverlap }) return
         if (!corrBlock.location.isChunkLoaded) corrBlock.chunk.load()
-
-        blocks.forEach { corrBlocks.add(it.location.correspondingLocation?.block ?: return@forEach) }
-        BlockPistonRetractEvent(corrBlock, corrBlocks, direction).callEvent()
+        corrBlocks.addAll(blocks.map { b -> b.location.correspondingLocation?.block ?: return@map null }.filterNotNull())
+        BlockPistonExtendEvent(corrBlock, corrBlocks, direction).callEvent()
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun BlockPistonRetractEvent.onPistonRetractEvent() {
         val corrBlock = block.location.correspondingLocation?.block ?: return
         val corrBlocks = mutableListOf<Block>()
@@ -32,7 +31,7 @@ object ExploitPreventionListener : Listener {
         if (blocks.all { b -> !b.location.inSectionOverlap }) return
         if (!corrBlock.location.isChunkLoaded) corrBlock.chunk.load()
 
-        blocks.forEach { corrBlocks.add(it.location.correspondingLocation?.block ?: return@forEach) }
+        corrBlocks.addAll(blocks.map { b -> b.location.correspondingLocation?.block ?: return@map null }.filterNotNull())
         BlockPistonRetractEvent(corrBlock, corrBlocks, direction).callEvent()
     }
 

--- a/src/main/kotlin/com/mineinabyss/deeperworld/synchronization/ExploitPreventionListener.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/synchronization/ExploitPreventionListener.kt
@@ -1,24 +1,45 @@
 package com.mineinabyss.deeperworld.synchronization
 
-import com.mineinabyss.deeperworld.world.section.correspondingSection
+import com.mineinabyss.deeperworld.world.section.correspondingLocation
+import com.mineinabyss.deeperworld.world.section.inSectionOverlap
+import io.papermc.paper.event.block.BlockBreakBlockEvent
+import org.bukkit.block.Block
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockPistonExtendEvent
 import org.bukkit.event.block.BlockPistonRetractEvent
+import org.bukkit.inventory.ItemStack
 
 object ExploitPreventionListener : Listener {
-    /** Disables pistons extending if they are in the overlap of two sections */
+
     @EventHandler
-    fun onPistonExtendEvent(event: BlockPistonExtendEvent) {
-        //TODO handle pistons properly instead of just cancelling the event
-        if (event.blocks.any { it.location.correspondingSection != null })
-            event.isCancelled = true
+    fun BlockPistonExtendEvent.onPistonExtendEvent() {
+        val corrBlock = block.location.correspondingLocation?.block ?: return
+        val corrBlocks = mutableListOf<Block>()
+
+        if (blocks.all { b -> !b.location.inSectionOverlap }) return
+        if (!corrBlock.location.isChunkLoaded) corrBlock.chunk.load()
+
+        blocks.forEach { corrBlocks.add(it.location.correspondingLocation?.block ?: return@forEach) }
+        BlockPistonRetractEvent(corrBlock, corrBlocks, direction).callEvent()
     }
 
-    /** Disables pistons retracting if they are in the overlap of two sections */
     @EventHandler
-    fun onPistonRetractEvent(event: BlockPistonRetractEvent) {
-        if (event.blocks.any { it.location.correspondingSection != null })
-            event.isCancelled = true
+    fun BlockPistonRetractEvent.onPistonRetractEvent() {
+        val corrBlock = block.location.correspondingLocation?.block ?: return
+        val corrBlocks = mutableListOf<Block>()
+
+        if (blocks.all { b -> !b.location.inSectionOverlap }) return
+        if (!corrBlock.location.isChunkLoaded) corrBlock.chunk.load()
+
+        blocks.forEach { corrBlocks.add(it.location.correspondingLocation?.block ?: return@forEach) }
+        BlockPistonRetractEvent(corrBlock, corrBlocks, direction).callEvent()
+    }
+
+    @EventHandler
+    fun BlockBreakBlockEvent.onPistonBreakBlock() {
+        val corrBlock = block.location.correspondingLocation?.block ?: return
+        val corrSource = source.location.correspondingLocation?.block ?: return
+        BlockBreakBlockEvent(corrBlock, corrSource, emptyList<ItemStack>()) // Empty drops to avoid dupes
     }
 }

--- a/src/main/kotlin/com/mineinabyss/deeperworld/synchronization/ExploitPreventionListener.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/synchronization/ExploitPreventionListener.kt
@@ -3,12 +3,12 @@ package com.mineinabyss.deeperworld.synchronization
 import com.mineinabyss.deeperworld.world.section.correspondingLocation
 import com.mineinabyss.deeperworld.world.section.inSectionOverlap
 import io.papermc.paper.event.block.BlockBreakBlockEvent
+import org.bukkit.Material
 import org.bukkit.block.Block
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockPistonExtendEvent
 import org.bukkit.event.block.BlockPistonRetractEvent
-import org.bukkit.inventory.ItemStack
 
 object ExploitPreventionListener : Listener {
 
@@ -39,7 +39,7 @@ object ExploitPreventionListener : Listener {
     @EventHandler
     fun BlockBreakBlockEvent.onPistonBreakBlock() {
         val corrBlock = block.location.correspondingLocation?.block ?: return
-        val corrSource = source.location.correspondingLocation?.block ?: return
-        BlockBreakBlockEvent(corrBlock, corrSource, emptyList<ItemStack>()) // Empty drops to avoid dupes
+        source.location.correspondingLocation?.block ?: return
+        corrBlock.setType(Material.AIR, false)
     }
 }

--- a/src/main/kotlin/com/mineinabyss/deeperworld/synchronization/SectionSyncListener.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/synchronization/SectionSyncListener.kt
@@ -107,6 +107,7 @@ object SectionSyncListener : Listener {
 
     @EventHandler
     fun BlockGrowEvent.syncBlockGrow() {
+        if (!block.location.inSectionOverlap) return
         newState.location.sync()
     }
 


### PR DESCRIPTION
StructureGrowEvent is called for trees etc, which was not synced before
BlockGrowEvent seems fine, not sure why it would lag buch but
BlockGrowEvent isnt called for bonemeal so manual interaction check

Fixes pistons, from my testing atleast. Calls the event in above section seems to fix
Calls event for pistons breaking stuff, clear drops for no dupes
This event should also be called if water breaks say crops in a transition

Tested with PhysicsEvent for rails and stuff and it seems to have improved since 1.16 or whenever we disabled it
Even when "cancelled" it triggered redstone so not much use in it

Updates some sign stuff to component cuz paper
Shulkers should have the same properties as chests, tho ill need to test this more (had similar issues with blocky so)<

Closes #26 