### PR TITLE
Feature/deeper world#25

### DIFF
--- a/src/main/kotlin/com/mineinabyss/deeperworld/services/WorldManager.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/services/WorldManager.kt
@@ -24,6 +24,7 @@ interface WorldManager {
      * Given x,y coords and a world, return the Section it is within
      *
      * @param x     The x coordinate
+     * @param y     The y coordinate
      * @param z     The z coordinate
      * @param world The world
      * @return The section or null if the location is not within a section.
@@ -70,6 +71,24 @@ interface WorldManager {
      * @param key The section key returned when registering this section
      */
     fun unregisterSection(key: SectionKey)
+
+    /**
+     * Gets the depth in blocks of the given location, taking sections into account
+     *
+     * @param location The location
+     * @return The depth of the given location in blocks, or null if location is not in a managed section
+     */
+    fun getDepthFor(location: Location): Int?
+
+    /**
+     * Gets the depth in blocks of the given position, taking sections into account
+     * @param x     The x coordinate
+     * @param y     The y coordinate
+     * @param z     The z coordinate
+     * @param world The world
+     * @return The depth of the given position in blocks, or null if position is not in a managed section
+     */
+    fun getDepthFor(x: Double, y: Double, z: Double, world: World): Int?
 
     /**
      * Gets an immutable copy of the currently loaded sections.

--- a/src/main/kotlin/com/mineinabyss/deeperworld/world/section/Section.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/world/section/Section.kt
@@ -56,5 +56,8 @@ data class Section(
     @Transient
     internal var belowKey: SectionKey = SectionKey.TERMINAL
 
+    @Transient
+    val height: Int = this.region.max.y - this.region.min.y
+
     override fun toString() = key.toString()
 }

--- a/src/main/kotlin/com/mineinabyss/deeperworld/world/section/SectionUtils.kt
+++ b/src/main/kotlin/com/mineinabyss/deeperworld/world/section/SectionUtils.kt
@@ -87,7 +87,7 @@ fun Location.sharedBetween(section: Section, otherSection: Section): Boolean {
 
 fun Section.overlapWith(other: Section): Int? {
     if (!isAdjacentTo(other)) return null
-    if(min(this.region.max.y, other.region.max.y) <= max(this.region.min.y, other.region.min.y)) return null
+    if (min(this.region.max.y, other.region.max.y) <= max(this.region.min.y, other.region.min.y)) return null
     // We decide which two points we are translating between.
     val (locA, locB) = when (isOnTopOf(other)) {
         true -> referenceBottom to other.referenceTop


### PR DESCRIPTION
This PR completes DeeperWorld#25

- Add depth calculation to the WorldManager API in the form of getDepthFor functions
  - I changed the algorithm a bit compared to how it was in MineInAbyss, to allow for any variation in the sections configuration. The MineInAbyss logic only worked if all sections were configured along the same horizontal axis.
- Introduce a _height_ property to the Section class
- Add a "depth" command that returns the depth of a given player (or the executor, if it is a player)

I'll change MineInAbyss to use the new methods after this PR is merged.